### PR TITLE
Add testdir config to handle matching classname

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This is a modification of the existing `xunit` reporter that ships with `Mocha`.
 - Sonar will reject reports that have a `classname` that mirrors a source file, eg. if you have a source file called `MyClass.js` then you cannot have a test with a `classname` of `MyClass`
 - Sonar interprets the `classname` field as a filename resulting in hard to read test reports in the Sonar UI (this is probably also the cause of the first issue)
 
-This reporter will generate `xunit` output that uses the concatenation of the suite and test titles as the test `name` and set the `classname` to a configurable constant so that name collisions can be avoided. If no `classname` is configured it will default to `Test`.
+This reporter will generate `xunit` output that uses the concatenation of the suite and test titles as the test `name` and set the `classname` to:
+
+- if `testdir` is defined in config, the test file relative path
+- else a configurable constant so that name collisions can be avoided. If no `classname` is configured it will default to `Test`.
 
 Usage
 -----
@@ -36,6 +39,18 @@ Configure the `classname` in `package.json` (optional)
   ...
 ```
 
+Configure the `testdir` in `package.json` (optional)
+
+```
+  ...
+  "config": {
+    "mocha-sonar-reporter": {
+      "testdir": "tests"
+    }
+  },
+  ...
+```
+
 Add the following to your `/sonar-project.properties` file
 
 ```
@@ -51,6 +66,7 @@ mocha -r mocha-sonar-reporter > reports/TEST-all.xml
 NB. feel free to change paths and file names above ;)
 
 NNB. Although not documented here, you may also like to use `Grunt` and the `grunt-mocha-test` plugin to do this and get coverage data, etc
+You can then use property `captureFile` to collect directly task output in designated file.
 
 
 License

--- a/lib/Sonar.js
+++ b/lib/Sonar.js
@@ -5,6 +5,7 @@
 
 var Base = require('mocha').reporters.Base;
 var escape = require('./escape');
+var path = require('path');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -65,8 +66,10 @@ function Sonar(runner, log) {
    */
 
   function test(test) {
+    var filename = extractClassName(test);
+
     var attrs = {
-        classname: process.env.npm_package_config_mocha_sonar_reporter_classname || 'Test'
+        classname: filename || process.env.npm_package_config_mocha_sonar_reporter_classname || 'Test'
       , name: !test.parent.fullTitle() || test.parent.fullTitle() === '' ? test.title : test.parent.fullTitle() + ' ' + test.title
       , time: (test.duration / 1000) || 0
     };
@@ -80,6 +83,25 @@ function Sonar(runner, log) {
     } else {
       log(tag('testcase', attrs, true) );
     }
+  }
+
+  /**
+   * Extract the classname (test relative file path) from the test absolute file path
+   * @param test
+   * @returns classname
+   */
+  function extractClassName(test) {
+    var relativeTestDir = process.env.npm_package_config_mocha_sonar_reporter_testdir;
+
+    if (relativeTestDir === undefined) {
+      return undefined;
+    }
+
+    var absoluteTestDir = path.join(process.cwd(), relativeTestDir);
+
+    var relativeFilePath = path.relative(absoluteTestDir, test.file);
+
+    return relativeFilePath.replace('.js', '');
   }
 }
 

--- a/mocks/Test.js
+++ b/mocks/Test.js
@@ -1,4 +1,4 @@
-function Test(title, duration, state, error) {
+function Test(title, duration, state, error, file) {
   this.title = title;
   this.duration = duration;
   this.state = state;
@@ -6,6 +6,7 @@ function Test(title, duration, state, error) {
   if (state === 'pending') {
     this.pending = true;
   }
+  this.file = file || '';
 }
 
 Test.prototype.slow = function() {


### PR DESCRIPTION
Hi,

this pullrequest aims to allow generate xunit report for Sonar with classname matching test file.
It uses a new property `testdir` in package.json config/mocha-sonar-reporter

Example:

``` xml
<testsuite name="Mocha Tests" tests="2" failures="0" errors="0" skipped="0" timestamp="Mon, 08 Dec 2014 10:00:39 GMT" time="0.002">
   <testcase classname="bar-spec" name="Bar #salut should return salut $name" time="0.001"/>
   <testcase classname="toto/foo-spec" name="Foo #hello should return hello $name" time="0"/>
</testsuite>
```
