### PR TITLE
Don't hardcode .js suffixes, allow any

### DIFF
--- a/lib/Sonar.js
+++ b/lib/Sonar.js
@@ -107,7 +107,9 @@ function Sonar(runner, log) {
 
     var relativeFilePath = path.relative(absoluteTestDir, test.file);
 
-    return relativeFilePath.replace('.js', '');
+    var suffixIndex = relativeFilePath.lastIndexOf('.');
+
+    return suffixIndex >= 0 ? relativeFilePath.substring(0, suffixIndex) : relativeFilePath;
   }
 
   function fileLogger() {


### PR DESCRIPTION
Making a pull request to allow other suffixes than .js on test files (eg .jsx in my case). 