### PR TITLE
Fix TypeError when beforeEach throws

### DIFF
--- a/lib/Sonar.js
+++ b/lib/Sonar.js
@@ -100,7 +100,7 @@ function Sonar(runner, log) {
     var relativeTestDir = process.env.npm_package_config_mocha_sonar_reporter_testdir;
     var classnameSuffix = process.env.npm_package_config_mocha_sonar_reporter_classnameSuffix || '';
 
-    if (relativeTestDir === undefined) {
+    if (relativeTestDir === undefined || test.file === undefined) {
       return undefined;
     }
 

--- a/mocks/Test.js
+++ b/mocks/Test.js
@@ -13,4 +13,9 @@ Test.prototype.slow = function() {
   return 200;
 };
 
+Test.prototype.withUndefinedFile = function() {
+  this.file = undefined;
+  return this;
+};
+
 module.exports = Test;

--- a/test/lib/Sonar.js
+++ b/test/lib/Sonar.js
@@ -114,6 +114,30 @@ describe('Sonar', function() {
     spy.args[4][0].should.equal('</testsuite>');
   });
 
+  it('should handle an undefined test file when testdir is configured', function() {
+    // given
+    var logStub = sinon.stub();
+    var runner = new Runner();
+    var sonar = new Sonar(runner, logStub);
+    var suite = new Suite('Suite');
+    var error = new Error('Test');
+
+    process.env.npm_package_config_mocha_sonar_reporter_testdir = 'foo';
+
+    suite.addTest(new Test('Test 1', 10, 'failed', error).withUndefinedFile());
+
+    // then
+    runner.on('end', function () {
+        logStub.callCount.should.equal(3);
+        logStub.should.have.been.calledWithMatch(/<testsuite name="Mocha Tests" tests="1" failures="1" errors="1" skipped="0"/);
+        logStub.should.have.been.calledWith('<testcase classname="Test" name="Suite Test 1" time="0.01" message="Test"><failure classname="Test" name="Suite Test 1" time="0.01" message="Test"><![CDATA[' + escape(error.stack) + ']]></failure></testcase>');
+        logStub.should.have.been.calledWith('</testsuite>');
+    });
+
+    // when
+    runner.run(suite);
+  });
+
   it('should support any file extension', function () {
     var spy = sinon.spy();
     var runner = new Runner();

--- a/test/mocks/Test.js
+++ b/test/mocks/Test.js
@@ -1,5 +1,5 @@
 var chai = require('chai');
-chai.should();
+var should = chai.should();
 
 var Test = require('../../mocks/Test');
 
@@ -21,6 +21,16 @@ describe('Test', function() {
     it('should return 200', function() {
       var test = new Test();
       test.slow().should.equal(200);
+    });
+  });
+
+  describe('#withEmptyFile', function() {
+    it('should return the test and set the file to undefined', function() {
+      // when
+      var test = new Test().withUndefinedFile();
+
+      // then
+      should.equal(test.file, undefined);
     });
   });
 });


### PR DESCRIPTION
When an error is thrown in beforeEach (and probably before, after and afterEach
as well), Test.file is undefined and the following error is thrown by
mocha-report-sonar:

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:8:11)
    at Object.posix.relative (path.js:496:3)
    at extractClassName
(/node_modules/mocha-sonar-reporter/lib/Sonar.js:110:33)
    at test
(/node_modules/mocha-sonar-reporter/lib/Sonar.js:75:20)
    at Array.forEach (native)
    at Runner.<anonymous>
(/node_modules/mocha-sonar-reporter/lib/Sonar.js:65:11)
    at emitNone (events.js:72:20)
    at Runner.emit (events.js:166:7)
    at
(/node_modules/mocha/lib/runner.js:735:12
    at done
(/node_modules/mocha/lib/runner.js:619:7)
    at next
(/node_modules/mocha/lib/runner.js:586:16)
    at done
(/node_modules/mocha/lib/runner.js:619:7)
    at next
(/node_modules/mocha/lib/runner.js:590:14)
    at done
(/node_modules/mocha/lib/runner.js:619:7)
    at next
(/node_modules/mocha/lib/runner.js:590:14)
    at Runner.hookErr
(/node_modules/mocha/lib/runner.js:461:7)
    at Runner.uncaught
(/node_modules/mocha/lib/runner.js:696:19)
    at process.uncaught
(/node_modules/mocha/lib/runner.js:727:10)
    at emitOne (events.js:77:13)
    at process.emit (events.js:169:7)
    at process._fatalException (node.js:219:26)
    at process._asyncFatalException [as _fatalException]
(/node_modules/continuation-local-storage/node_modules/async-listener/glue.js:211:34)
```

This is caused by the class name extracting calling path.relative with
undefined Test.file.

Here we protect extractClassName from doing so.